### PR TITLE
fix: capture all ssh errors

### DIFF
--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -75,10 +75,10 @@ def upload_results(job_hash, results):
                 result_dict=upload_record_docDB, 
                 collection_name="mle_fitting"
         )  # Note that this will add _id automatically to upload_record_docDB
-    except ServerSelectionTimeoutError as e:
+    except Exception as e:
         upload_status.update(
             {
-                "docDB_upload_status": "failed; too many ServerSelectionTimeoutErrors",
+                "docDB_upload_status": "failed; too many SSH Errors",
                 "docDB_id": None,
                 "collection_name": None,
             }

--- a/code/utils/docDB_io.py
+++ b/code/utils/docDB_io.py
@@ -24,9 +24,9 @@ def retry_on_ssh_timeout(max_retries=MAX_SSH_RETRIES, timeout=TIMEOUT):
             while retries < max_retries:
                 try:
                     return func(*args, **kwargs)
-                except ServerSelectionTimeoutError as e:
+                except Exception as e:
                     retries += 1
-                    logger.warning(f"ServerSelectionTimeoutError encountered. Retry {retries}/{max_retries}...")
+                    logger.warning(f"SSH error encountered. Retry {retries}/{max_retries}...")
                     if retries >= max_retries:
                         logger.error("Max retries reached. Raising exception.")
                         raise


### PR DESCRIPTION
- This works!! Example log:
```
2024-09-19 23:41:13,841 - analysis_wrappers.mle_fitting - INFO - MLE fitting for 717617_2024-07-15_09-48-06.nwb with ForagerLossCounting
2024-09-19 23:41:14,789 - aind_dynamic_foraging_models.generative_model.base - INFO - Fitting the model using the whole dataset...
2024-09-19 23:41:16,834 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validating the model using 10-fold cross-validation...
2024-09-19 23:41:16,835 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 1/10...
2024-09-19 23:41:18,866 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 2/10...
2024-09-19 23:41:20,931 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 3/10...
2024-09-19 23:41:23,132 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 4/10...
2024-09-19 23:41:25,264 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 5/10...
2024-09-19 23:41:27,824 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 6/10...
2024-09-19 23:41:30,006 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 7/10...
2024-09-19 23:41:32,161 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 8/10...
2024-09-19 23:41:34,583 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 9/10...
2024-09-19 23:41:36,520 - aind_dynamic_foraging_models.generative_model.base - INFO - Cross-validation fold 10/10...
2024-09-19 23:41:38,650 - utils.aws_io - INFO - Uploaded fitted_session.png to S3
2024-09-19 23:41:38,969 - utils.aws_io - INFO - Saved fitted_session.png locally
2024-09-19 23:41:38,970 - utils.aws_io - INFO - Uploaded forager.pkl to S3
2024-09-19 23:41:39,007 - utils.aws_io - INFO - Saved forager.pkl locally
2024-09-19 23:41:39,022 - paramiko.transport - ERROR - Exception (client): Error reading SSH protocol banner[Errno 104] Connection reset by peer
2024-09-19 23:41:39,023 - paramiko.transport - ERROR - Traceback (most recent call last):
2024-09-19 23:41:39,023 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/transport.py", line 2369, in _check_banner
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -     buf = self.packetizer.readline(timeout)
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/packet.py", line 395, in readline
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -     buf += self._read_timeout(timeout)
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/packet.py", line 663, in _read_timeout
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -     x = self.__socket.recv(128)
2024-09-19 23:41:39,024 - paramiko.transport - ERROR - ConnectionResetError: [Errno 104] Connection reset by peer
2024-09-19 23:41:39,024 - paramiko.transport - ERROR - 
2024-09-19 23:41:39,024 - paramiko.transport - ERROR - During handling of the above exception, another exception occurred:
2024-09-19 23:41:39,024 - paramiko.transport - ERROR - 
2024-09-19 23:41:39,024 - paramiko.transport - ERROR - Traceback (most recent call last):
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/transport.py", line 2185, in run
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -     self._check_banner()
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/transport.py", line 2373, in _check_banner
2024-09-19 23:41:39,024 - paramiko.transport - ERROR -     raise SSHException(
2024-09-19 23:41:39,025 - paramiko.transport - ERROR - paramiko.ssh_exception.SSHException: Error reading SSH protocol banner[Errno 104] Connection reset by peer
2024-09-19 23:41:39,025 - paramiko.transport - ERROR - 
2024-09-19 23:41:39,025 - sshtunnel.SSHTunnelForwarder - ERROR - Could not connect to gateway 34.213.124.112:22 : Error reading SSH protocol banner[Errno 104] Connection reset by peer
2024-09-19 23:41:39,025 - utils.docDB_io - WARNING - SSH error encountered. Retry 1/10...
2024-09-19 23:41:44,034 - paramiko.transport - ERROR - Exception (client): Error reading SSH protocol banner
2024-09-19 23:41:44,034 - paramiko.transport - ERROR - Traceback (most recent call last):
2024-09-19 23:41:44,034 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/transport.py", line 2369, in _check_banner
2024-09-19 23:41:44,035 - paramiko.transport - ERROR -     buf = self.packetizer.readline(timeout)
2024-09-19 23:41:44,035 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/packet.py", line 395, in readline
2024-09-19 23:41:44,035 - paramiko.transport - ERROR -     buf += self._read_timeout(timeout)
2024-09-19 23:41:44,035 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/packet.py", line 665, in _read_timeout
2024-09-19 23:41:44,035 - paramiko.transport - ERROR -     raise EOFError()
2024-09-19 23:41:44,035 - paramiko.transport - ERROR - EOFError
2024-09-19 23:41:44,035 - paramiko.transport - ERROR - 
2024-09-19 23:41:44,035 - paramiko.transport - ERROR - During handling of the above exception, another exception occurred:
2024-09-19 23:41:44,035 - paramiko.transport - ERROR - 
2024-09-19 23:41:44,035 - paramiko.transport - ERROR - Traceback (most recent call last):
2024-09-19 23:41:44,035 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/transport.py", line 2185, in run
2024-09-19 23:41:44,035 - paramiko.transport - ERROR -     self._check_banner()
2024-09-19 23:41:44,035 - paramiko.transport - ERROR -   File "/opt/conda/lib/python3.9/site-packages/paramiko/transport.py", line 2373, in _check_banner
2024-09-19 23:41:44,036 - paramiko.transport - ERROR -     raise SSHException(
2024-09-19 23:41:44,036 - paramiko.transport - ERROR - paramiko.ssh_exception.SSHException: Error reading SSH protocol banner
2024-09-19 23:41:44,036 - paramiko.transport - ERROR - 
2024-09-19 23:41:44,036 - sshtunnel.SSHTunnelForwarder - ERROR - Could not connect to gateway 34.213.124.112:22 : Error reading SSH protocol banner
2024-09-19 23:41:44,036 - utils.docDB_io - WARNING - SSH error encountered. Retry 2/10...
2024-09-19 23:41:49,325 - paramiko.transport - INFO - Connected (version 2.0, client OpenSSH_8.7)
2024-09-19 23:41:52,755 - paramiko.transport - INFO - Authentication (password) successful!
2024-09-19 23:41:53,142 - root - INFO - {'version': '5.0.0', 'versionArray': [5, 0, 0, 0], 'bits': 64, 'maxBsonObjectSize': 16777216, 'ok': 1.0, 'operationTime': Timestamp(1726789313, 1)}
2024-09-19 23:41:53,142 - root - INFO - Connected to docdb-us-west-2-dev.cluster-c7yonahisdgp.us-west-2.docdb.amazonaws.com:27017 as han.hou@alleninstitute.org
2024-09-19 23:41:53,213 - root - INFO - DocDB SSH session closed.
2024-09-19 23:41:53,214 - utils.docDB_io - INFO - Inserted 66ecb6c1140c3a50c63914f1 to mle_fitting in docDB
2024-09-19 23:41:53,226 - utils.aws_io - INFO - Uploaded docDB_record.json to S3
2024-09-19 23:41:53,342 - utils.aws_io - INFO - Saved docDB_record.json locally

```

- There are even 6/10 attempts! See this [query](https://api.allenneuraldynamics-test.org/v1/behavior_analysis/job_manager?filter={%22log%22:%20{%22$regex%22:%20%22Retry%206/10%22}}) 